### PR TITLE
add dynamic partials that display madlibs correctly

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -7,7 +7,7 @@
     </head>
     <body>
         <header>
-            <h1>Test Homepage</h1>
+            <h1>RadLibs</h1>
         </header>
         <main>
             {{{ body }}}

--- a/views/partials/mary-lamb.handlebars
+++ b/views/partials/mary-lamb.handlebars
@@ -1,4 +1,4 @@
 <div>
     <h1>{{ title }}</h1>
-    <p>{{blanks[0].content}} had a {{blanks[1].content}} {{blanks[2].content}}, it's {{blanks[3].content}} was {{blanks[4].content}} as {{blanks[5].content}}</p>
+    <p><strong>{{blanks.0.content}}</strong> had a <strong>{{blanks.1.content}}</strong> <strong>{{blanks.2.content}}</strong> it's <strong>{{blanks.3.content}}</strong> was <strong>{{blanks.4.content}}</strong> as <strong>{{blanks.5.content}}</strong>, and everywhere that <strong>{{blanks.0.content}}</strong> went, the <strong>{{blanks.2.content}}</strong> was sure to go!  It followed her to <strong>{{blanks.6.content}}</strong> one day, which was against the rules.  It made the children <strong>{{blanks.7.content}}</strong> and <strong>{{blanks.8.content}}</strong> to see a <strong>{{blanks.2.content}}</strong> at <strong>{{blanks.6.content}}</strong>!</p>
 </div>

--- a/views/partials/row-row.handlebars
+++ b/views/partials/row-row.handlebars
@@ -1,3 +1,4 @@
 <div>
-    <h1>Row, Row, Row Your Boat</h1>
+    <h1>{{title}}</h1>
+    <p><strong>{{blanks.0.content}}</strong>, <strong>{{blanks.0.content}}</strong>, <strong>{{blanks.0.content}}</strong> your <strong>{{blanks.1.content}}</strong>, <strong>{{blanks.2.content}}</strong> down the <strong>{{blanks.3.content}}</strong>, <strong>{{blanks.4.content}}</strong>, <strong>{{blanks.4.content}}</strong>, <strong>{{blanks.4.content}}</strong>, <strong>{{blanks.4.content}}</strong>, life is but a <strong>{{blanks.5.content}}</strong>!</p>
 </div>


### PR DESCRIPTION
Working sketches of handlebars partials displaying each radlib.  Visit `/radlibs/:id` where `:id` is 1, 2, 3, or 4, to see in action.
(Edit: corrected path.)